### PR TITLE
v0.10.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "alterware-launcher"
-version = "0.10.8"
+version = "0.10.9"
 dependencies = [
  "blake3",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alterware-launcher"
-version = "0.10.8"
+version = "0.10.9"
 edition = "2021"
 build = "res/build.rs"
 
@@ -46,4 +46,4 @@ serial_test = "3.2.0"
 [package.metadata.winresource]
 OriginalFilename = "alterware-launcher.exe"
 FileDescription = "AlterWare Launcher"
-ProductName = "github.com/mxve/alterware-launcher"
+ProductName = "github.com/alterware/alterware-launcher"

--- a/src/global.rs
+++ b/src/global.rs
@@ -8,7 +8,7 @@ use std::sync::Mutex;
 
 use crate::cdn::{Hosts, Region, Server};
 
-pub const GH_OWNER: &str = "mxve";
+pub const GH_OWNER: &str = "alterware";
 pub const GH_REPO: &str = "alterware-launcher";
 pub const GH_IW4X_OWNER: &str = "iw4x";
 pub const GH_IW4X_REPO: &str = "iw4x-client";


### PR DESCRIPTION
As part of this transition, IW4x has become its own separate project. AlterWare will need to merge the launcher under  https://github.com/alterware/alterware-launcher. This move allows anyone to work on whichever projects they want without having to maintain a product  (the launcher) for two separate projects.